### PR TITLE
tfdocgen: Remove unneccesary `make check`

### DIFF
--- a/Formula/tfdocgen.rb
+++ b/Formula/tfdocgen.rb
@@ -28,7 +28,6 @@ class Tfdocgen < Formula
     system "autoreconf", "-i", "-f"
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
-    system "make", "check"
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`make check` doesn't do anything in this project so it was removed. 