### PR TITLE
libticalcs: fix url

### DIFF
--- a/Formula/lib/libticalcs.rb
+++ b/Formula/lib/libticalcs.rb
@@ -1,9 +1,9 @@
 class Libticalcs < Formula
   desc "TiCalcs library is a part of the TiLP project"
   homepage "http://lpg.ticalc.org/prj_tilp"
-  url "https://github.com/debrouxl/tilibs/archive/1eb19a48f4c40fdc1093949603d3111e22ed9962.tar.gz"
+  url "https://github.com/debrouxl/tilibs/archive/c9d377e3ef2af8f435f62896b3f859c1365d7a59.tar.gz"
   version "1.1.10"
-  sha256 "263a12290496a03423356f5d07233d9ec1cad518f0ebedfc29b82d4660084589"
+  sha256 "22d22d361032b71842adb45055a249ab4994709198445380285c4a291b1be801"
   license "GPL-2.0-or-later"
   revision 4
   head "https://github.com/debrouxl/tilibs.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fix URL for libticalcs. 