### PR TITLE
gfm and tilp: change atk to at-spi2-core

### DIFF
--- a/Formula/g/gfm.rb
+++ b/Formula/g/gfm.rb
@@ -17,7 +17,7 @@ class Gfm < Formula
     sha256 x86_64_linux: "4423622e087fa83265a9cbdebd39794ff74200b9f3ac5fc0eb0849d7a822e847"
   end
 
-  depends_on "atk" => :build
+  depends_on "at-spi2-core" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cairo" => :build

--- a/Formula/t/tilp.rb
+++ b/Formula/t/tilp.rb
@@ -17,7 +17,7 @@ class Tilp < Formula
     sha256 x86_64_linux: "35edfbc8522049e0418c20e24094578d9c9f3d0ac91981a53cdbe5aa9cb9de6a"
   end
 
-  depends_on "atk" => :build
+  depends_on "at-spi2-core" => :build
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cairo" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Change build requirement from `atk` to `at-spi2-core` to reflect the Formula being renamed. 