### PR TITLE
tfdocgen: use `{assert,refute}_path_exists`

### DIFF
--- a/Formula/t/tfdocgen.rb
+++ b/Formula/t/tfdocgen.rb
@@ -49,6 +49,6 @@ class Tfdocgen < Formula
     resource("testdocs").stage testpath/"libs"
     Dir.chdir("#{testpath}/libs/libticables/trunk")
     system bin/"tfdocgen", "./"
-    assert_predicate testpath/"libs/libticables/trunk/docs/html/api.html", :exist?
+    assert_path_exists testpath/"libs/libticables/trunk/docs/html/api.html"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Replace `assert_predicate` with `assert_path_exists` to conform with new accepted style. 