### PR TITLE
libudfread: add `no_autobump!`

### DIFF
--- a/Formula/lib/libudfread.rb
+++ b/Formula/lib/libudfread.rb
@@ -10,6 +10,8 @@ class Libudfread < Formula
     url :head
   end
 
+  no_autobump! because: :incompatible_version_format
+
   bottle do
     root_url "https://ghcr.io/v2/jlp04/homebrew"
     sha256 cellar: :any,                 arm64_sequoia: "2503af3f963044f09e4363eedf3604f5553a9347ef2977fc968a2865f6d65995"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Adding `no_autobump!` to `libudfread` due to `brew livecheck` reporting an old version number. 