### PR TITLE
clamtk: fix tests for perlbrew

### DIFF
--- a/Formula/c/clamtk.rb
+++ b/Formula/c/clamtk.rb
@@ -311,8 +311,10 @@ class Clamtk < Formula
       EOS
     end
     inreplace "test", "#!#{HOMEBREW_PREFIX}/opt/perl/bin/perl", "#!/usr/bin/env perl" if build.with? "perlbrew"
-    ENV.prepend_create_path "PERL5LIB", "#{share}/perl5/vendor_perl" if build.without? "perlbrew"
-    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+    if build.without? "perlbrew"
+      ENV.prepend_create_path "PERL5LIB", "#{share}/perl5/vendor_perl"
+      ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+    end
     chmod "+x", "test"
     system "./test"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixing tests for perlbrew installations so that they don't pass environment variables referencing directories that don't exist. 