### PR TITLE
formulae: use Pathname syntax for testpath paths in tests

### DIFF
--- a/Formula/t/tfdocgen.rb
+++ b/Formula/t/tfdocgen.rb
@@ -47,7 +47,7 @@ class Tfdocgen < Formula
     shell_output("#{bin}/tfdocgen --version")
     shell_output("#{bin}/tfdocgen --help")
     resource("testdocs").stage testpath/"libs"
-    Dir.chdir("#{testpath}/libs/libticables/trunk")
+    Dir.chdir(testpath/"libs/libticables/trunk")
     system bin/"tfdocgen", "./"
     assert_path_exists testpath/"libs/libticables/trunk/docs/html/api.html"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Use Pathname syntax for testpath paths in tests to align with new standards on `homebrew/core`. 