### PR TITLE
tilp: remove `XML::Parser` dependency on Linux

### DIFF
--- a/Formula/t/tilp.rb
+++ b/Formula/t/tilp.rb
@@ -68,22 +68,9 @@ class Tilp < Formula
     depends_on "perl" => :build
     depends_on "expat"
     depends_on "zlib-ng-compat"
-
-    resource "XML::Parser" do
-      url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.56.tar.gz"
-      sha256 "a78bfcd3834fde7411acee2f5fcd74deeecfbaa8cee86f16c33c42dde2fd8fff"
-    end
   end
 
   def install
-    if OS.linux?
-      ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
-      resource("XML::Parser").stage do
-        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
-        system "make", "PERL5LIB=#{ENV["PERL5LIB"]}"
-        system "make", "install"
-      end
-    end
     Dir.chdir("tilp/trunk")
     system "autoreconf", "-i", "-f"
     system "./configure", *std_configure_args, "--disable-silent-rules"

--- a/Formula/t/tilp.rb
+++ b/Formula/t/tilp.rb
@@ -5,7 +5,7 @@ class Tilp < Formula
   version "1.19"
   sha256 "33347790504b25a5b33bdf64f950ff86584e7668644a5f275441348e06b763c3"
   license "GPL-2.0-or-later"
-  revision 6
+  revision 7
   compatibility_version 1
   head "https://github.com/debrouxl/tilp_and_gfm.git", branch: "master"
   livecheck do
@@ -70,8 +70,8 @@ class Tilp < Formula
     depends_on "zlib-ng-compat"
 
     resource "XML::Parser" do
-      url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.47.tar.gz"
-      sha256 "ad4aae643ec784f489b956abe952432871a622d4e2b5c619e8855accbfc4d1d8"
+      url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.56.tar.gz"
+      sha256 "a78bfcd3834fde7411acee2f5fcd74deeecfbaa8cee86f16c33c42dde2fd8fff"
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*

-----
Remove dependency on `XML::Parser` perl module on Linux. 