### PR TITLE
libglade: Update system type files to fix building on arm64 linux

### DIFF
--- a/Formula/lib/libglade.rb
+++ b/Formula/lib/libglade.rb
@@ -30,8 +30,32 @@ class Libglade < Formula
     depends_on "harfbuzz"
   end
 
+  resource "config.guess" do
+    url "https://git.savannah.gnu.org/cgit/config.git/plain/config.guess"
+    version "2026-05-17"
+    sha256 "ac18bbd7dc3769e1646af49ebba331a391829f4a73579b735dc8d439bd1c7f07"
+    livecheck do
+      url "https://git.savannah.gnu.org/cgit/config.git/plain/config.guess"
+      regex(/timestamp='(.*)'/)
+      strategy :page_match
+    end
+  end
+
+  resource "config.sub" do
+    url "https://git.savannah.gnu.org/cgit/config.git/plain/config.sub"
+    version "2026-05-17"
+    sha256 "f9a31e9a3f5b7cbeb8d8c3f2015895a51e7222130114c9c363fcbccd78e4bf6b"
+    livecheck do
+      url "https://git.savannah.gnu.org/cgit/config.git/plain/config.sub"
+      regex(/timestamp='(.*)'/)
+      strategy :page_match
+    end
+  end
+
   def install
     ENV.append "LDFLAGS", "-lgmodule-2.0"
+    resource("config.guess").stage buildpath
+    resource("config.sub").stage buildpath
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*

-----
This adds up-to-date `config.guess` and `config.sub` files to allow building on arm64 Linux. 