### PR TITLE
Remove Extra Line from `brew-vulns` Workflows that is No Longer Needed

### DIFF
--- a/.github/workflows/pr-vuln-check.yml
+++ b/.github/workflows/pr-vuln-check.yml
@@ -29,8 +29,7 @@ jobs:
                 names=$(git diff --name-only --diff-filter=AM "${BASE_SHA}" -- Formula/ \
                   | xargs -r -n1 basename \
                   | sed 's/\.rb$//' \
-                  | tr '\n' ' ' \
-                  | xargs)
+                  | tr '\n' ' ')
                 echo "names=${names}" >> "${GITHUB_OUTPUT}"
 
             - name: Check vulnerabilities

--- a/.github/workflows/vuln-check-and-sbom.yml
+++ b/.github/workflows/vuln-check-and-sbom.yml
@@ -30,8 +30,7 @@ jobs:
                 names=$(find Formula -name '*.rb' -print0 \
                   | xargs -0 -r -n1 basename \
                   | sed 's/\.rb$//' \
-                  | tr '\n' ' ' \
-                  | xargs)
+                  | tr '\n' ' ')
                 echo "names=${names}" >> "${GITHUB_OUTPUT}"
 
             - name: Check vulnerabilities


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*

-----
This removes an extra line from each of the `brew-vulns` workflows, which should no longer be needed after 0ca8d42262687a65859d72f7a607c06f550cba56 and 4b394d13743ae61c55159765111d6d6b8c2f6f17. 